### PR TITLE
chore: rename `dest` to `dst` to align with `src`

### DIFF
--- a/src/client/connections/messaging.rs
+++ b/src/client/connections/messaging.rs
@@ -138,7 +138,7 @@ impl Session {
             .await?
             .bls()
             .ok_or(Error::NoBlsSectionKey)?;
-        let dest_section_name = XorName::from(client_signed.public_key);
+        let dst_section_name = XorName::from(client_signed.public_key);
 
         let msg = ClientMsg::Process(ProcessMsg::Cmd {
             id: msg_id,
@@ -146,7 +146,7 @@ impl Session {
             client_signed,
         });
 
-        let msg_bytes = msg.serialize(dest_section_name, section_pk)?;
+        let msg_bytes = msg.serialize(dst_section_name, section_pk)?;
 
         // Send message to all Elders concurrently
         let mut tasks = Vec::default();
@@ -204,14 +204,14 @@ impl Session {
             .await?
             .bls()
             .ok_or(Error::NoBlsSectionKey)?;
-        let dest_section_name = XorName::from(client_signed.public_key);
+        let dst_section_name = XorName::from(client_signed.public_key);
 
         let msg = ClientMsg::Process(ProcessMsg::Cmd {
             id: msg_id,
             cmd,
             client_signed,
         });
-        let msg_bytes = msg.serialize(dest_section_name, section_pk)?;
+        let msg_bytes = msg.serialize(dst_section_name, section_pk)?;
 
         let _ = pending_transfers.write().await.insert(msg_id, sender);
 
@@ -262,7 +262,7 @@ impl Session {
             .await?
             .bls()
             .ok_or(Error::NoBlsSectionKey)?;
-        let dest_section_name = XorName::from(client_signed.public_key);
+        let dst_section_name = XorName::from(client_signed.public_key);
 
         let msg_id = MessageId::new();
         let msg = ClientMsg::Process(ProcessMsg::Query {
@@ -271,7 +271,7 @@ impl Session {
             client_signed,
         });
 
-        let msg_bytes = msg.serialize(dest_section_name, section_pk)?;
+        let msg_bytes = msg.serialize(dst_section_name, section_pk)?;
 
         // We select the NUM_OF_ELDERS_SUBSET_FOR_QUERIES closest
         // connected Elders to the data we are querying
@@ -481,13 +481,13 @@ impl Session {
             bootstrapped_peer
         );
 
-        let dest_section_name = XorName::from(client_pk);
+        let dst_section_name = XorName::from(client_pk);
 
         // FIXME: we don't know our section PK. We must supply a pk for now we do a random one...
         let random_section_pk = bls::SecretKey::random().public_key();
 
         let msg = SectionInfoMsg::GetSectionQuery(client_pk)
-            .serialize(dest_section_name, random_section_pk)?;
+            .serialize(dst_section_name, random_section_pk)?;
 
         self.endpoint()?
             .send_message(msg, bootstrapped_peer)

--- a/src/messaging/client/mod.rs
+++ b/src/messaging/client/mod.rs
@@ -179,10 +179,10 @@ impl ClientMsg {
     /// Serialize this Message into bytes ready to be sent over the wire.
     pub fn serialize(
         &self,
-        dest: XorName,
-        dest_section_pk: BlsPublicKey,
+        dst: XorName,
+        dst_section_pk: BlsPublicKey,
     ) -> crate::messaging::Result<Bytes> {
-        WireMsg::serialize_client_msg(self, dest, dest_section_pk)
+        WireMsg::serialize_client_msg(self, dst, dst_section_pk)
     }
 
     /// Gets the message ID.
@@ -641,9 +641,9 @@ mod tests {
         });
 
         // test msgpack serialization
-        let dest = XorName::random();
-        let dest_section_pk = bls::SecretKey::random().public_key();
-        let serialized = message.serialize(dest, dest_section_pk)?;
+        let dst = XorName::random();
+        let dst_section_pk = bls::SecretKey::random().public_key();
+        let serialized = message.serialize(dst, dst_section_pk)?;
         let deserialized = ClientMsg::from(serialized)?;
         assert_eq!(deserialized, message);
 

--- a/src/messaging/node/agreement.rs
+++ b/src/messaging/node/agreement.rs
@@ -73,7 +73,7 @@ pub enum Proposal {
         // Previous name if relocated.
         previous_name: Option<XorName>,
         // The key of the destination section that the joining node knows, if any.
-        destination_key: Option<BlsPublicKey>,
+        dst_key: Option<BlsPublicKey>,
     },
 
     // Proposal to remove a node from our section

--- a/src/messaging/node/mod.rs
+++ b/src/messaging/node/mod.rs
@@ -83,10 +83,10 @@ impl RoutingMsg {
     /// serialize this RoutingMsg into bytes ready to be sent over the wire.
     pub fn serialize(
         &self,
-        dest: XorName,
-        dest_section_pk: BlsPublicKey,
+        dst: XorName,
+        dst_section_pk: BlsPublicKey,
     ) -> crate::messaging::Result<Bytes> {
-        WireMsg::serialize_routing_msg(self, dest, dest_section_pk)
+        WireMsg::serialize_routing_msg(self, dst, dst_section_pk)
     }
 }
 

--- a/src/messaging/node/node_msg.rs
+++ b/src/messaging/node/node_msg.rs
@@ -118,11 +118,11 @@ impl NodeMsg {
     /// serialize this NodeCmd message into bytes ready to be sent over the wire.
     pub fn serialize(
         &self,
-        dest: XorName,
-        dest_section_pk: BlsPublicKey,
+        dst: XorName,
+        dst_section_pk: BlsPublicKey,
         src_section_pk: Option<BlsPublicKey>,
     ) -> crate::messaging::Result<Bytes> {
-        WireMsg::serialize_node_msg(self, dest, dest_section_pk, src_section_pk)
+        WireMsg::serialize_node_msg(self, dst, dst_section_pk, src_section_pk)
     }
 }
 

--- a/src/messaging/node/relocation.rs
+++ b/src/messaging/node/relocation.rs
@@ -22,9 +22,9 @@ pub struct RelocateDetails {
     pub pub_id: XorName,
     /// Relocation destination - the node will be relocated to a section whose prefix matches this
     /// name.
-    pub destination: XorName,
+    pub dst: XorName,
     /// The BLS key of the destination section used by the relocated node to verify messages.
-    pub destination_key: BlsPublicKey,
+    pub dst_key: BlsPublicKey,
     /// The age the node will have post-relocation.
     pub age: u8,
 }
@@ -47,5 +47,5 @@ pub struct RelocatePayload {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub struct RelocatePromise {
     pub name: XorName,
-    pub destination: XorName,
+    pub dst: XorName,
 }

--- a/src/messaging/node/variant.rs
+++ b/src/messaging/node/variant.rs
@@ -16,7 +16,7 @@ use super::{
     signed::SignedShare,
     RoutingMsg,
 };
-use crate::messaging::{DestInfo, SectionAuthorityProvider};
+use crate::messaging::{DstInfo, SectionAuthorityProvider};
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::message::Message as DkgMessage;
 use hex_fmt::HexFmt;
@@ -68,7 +68,7 @@ pub enum Variant {
     /// source in order for them to provide new proof that the node would trust.
     BouncedUntrustedMessage {
         msg: Box<RoutingMsg>,
-        dest_info: DestInfo,
+        dst_info: DstInfo,
     },
     /// Sent to the new elder candidates to start the DKG process.
     DkgStart {
@@ -141,10 +141,10 @@ impl Debug for Variant {
             Self::JoinAsRelocatedResponse(response) => {
                 write!(f, "JoinAsRelocatedResponse({:?})", response)
             }
-            Self::BouncedUntrustedMessage { msg, dest_info } => f
+            Self::BouncedUntrustedMessage { msg, dst_info } => f
                 .debug_struct("BouncedUntrustedMessage")
                 .field("message", msg)
-                .field("dest_info", dest_info)
+                .field("dst_info", dst_info)
                 .finish(),
             Self::DkgStart {
                 dkg_key,

--- a/src/messaging/section_info/mod.rs
+++ b/src/messaging/section_info/mod.rs
@@ -67,9 +67,9 @@ impl SectionInfoMsg {
     /// serialize this Query into bytes ready to be sent over the wire.
     pub fn serialize(
         &self,
-        dest: XorName,
-        dest_section_pk: BlsPublicKey,
+        dst: XorName,
+        dst_section_pk: BlsPublicKey,
     ) -> crate::messaging::Result<Bytes> {
-        WireMsg::serialize_section_info_msg(self, dest, dest_section_pk)
+        WireMsg::serialize_section_info_msg(self, dst, dst_section_pk)
     }
 }

--- a/src/node/node/messaging.rs
+++ b/src/node/node/messaging.rs
@@ -33,14 +33,14 @@ pub(crate) async fn send(msg: OutgoingMsg, network: &Network) -> Result<()> {
     };
 
     let dst_name = msg.dst.name().ok_or(Error::NoDestinationName)?;
-    let dest_section_pk = network
+    let dst_section_pk = network
         .get_section_pk_by_name(&dst_name)
         .await?
         .bls()
         .ok_or(Error::NoSectionPublicKeyKnown(dst_name))?;
 
     let content = match msg.msg.clone() {
-        MsgType::Client(msg) => msg.serialize(dst_name, dest_section_pk)?,
+        MsgType::Client(msg) => msg.serialize(dst_name, dst_section_pk)?,
         MsgType::Node(msg) => {
             let src_section_pk = if itinerary.aggregate_at_dst() {
                 Some(
@@ -53,7 +53,7 @@ pub(crate) async fn send(msg: OutgoingMsg, network: &Network) -> Result<()> {
             } else {
                 None
             };
-            msg.serialize(dst_name, dest_section_pk, src_section_pk)?
+            msg.serialize(dst_name, dst_section_pk, src_section_pk)?
         }
     };
 

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -39,7 +39,7 @@ use xor_name::XorName;
 /// is also an internal message.
 /// Finally, an internal message might be destined for messaging
 /// module, by which it leaves the process boundary of this node
-/// and is sent on the wire to some other destination(s) on the network.
+/// and is sent on the wire to some other dst(s) on the network.
 
 /// Vec of NodeDuty
 pub type NodeDuties = Vec<NodeDuty>;

--- a/src/routing/CHANGELOG.md
+++ b/src/routing/CHANGELOG.md
@@ -141,7 +141,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* update message bytes directly for dest change ([d253690](https://github.com/maidsafe/sn_routing/commit/d2536909c25f1981a31d47eea9cd8016ed5a012a))
+* update message bytes directly for dst change ([d253690](https://github.com/maidsafe/sn_routing/commit/d2536909c25f1981a31d47eea9cd8016ed5a012a))
 
 ## [0.71.0](https://github.com/maidsafe/sn_routing/compare/v0.70.0...v0.71.0) (2021-05-25)
 
@@ -691,7 +691,7 @@ a public struct but won't trigger the version update automatically.
 
 * respond with GetSectionResponse::Redirect on missing pk set ([69a1fb8](https://github.com/maidsafe/sn_routing/commit/69a1fb840cbbb54b8ccb5af8856e3991d3ac46dd))
 * **bootstrap:** avoid duplicate GetSectionRequest ([84327e2](https://github.com/maidsafe/sn_routing/commit/84327e2521dfcace503886e3d4b79c3118cc4464))
-* **bootstrap:** require GetSectionResponse to match our destination, not name ([4f484f1](https://github.com/maidsafe/sn_routing/commit/4f484f1ea93f5d83180d5c77fcb5b3a680322d31))
+* **bootstrap:** require GetSectionResponse to match our dst, not name ([4f484f1](https://github.com/maidsafe/sn_routing/commit/4f484f1ea93f5d83180d5c77fcb5b3a680322d31))
 * **stress-test:** fix probe message sending ([a8a184c](https://github.com/maidsafe/sn_routing/commit/a8a184c70f57801140d4fb521b230485ab353727))
 
 ### [0.47.2](https://github.com/maidsafe/sn_routing/compare/v0.47.1...v0.47.2) (2021-03-02)
@@ -747,7 +747,7 @@ change
 
 ### Features
 
-* **accumulation:** add support for accumlation at dest node ([f892838](https://github.com/maidsafe/sn_routing/commit/f892838c994f243e6be17b5276b1c80ff10f5c3a))
+* **accumulation:** add support for accumlation at dst node ([f892838](https://github.com/maidsafe/sn_routing/commit/f892838c994f243e6be17b5276b1c80ff10f5c3a))
 
 
 ### Bug Fixes

--- a/src/routing/agreement/dkg.rs
+++ b/src/routing/agreement/dkg.rs
@@ -9,7 +9,7 @@
 use super::{DkgFailureSignedSetUtils, DkgFailureSignedUtils};
 use crate::messaging::{
     node::{DkgFailureSigned, DkgFailureSignedSet, DkgKey, ElderCandidates, RoutingMsg, Variant},
-    DestInfo, DstLocation, SectionAuthorityProvider,
+    DstInfo, DstLocation, SectionAuthorityProvider,
 };
 use crate::routing::routing::{
     crypto::{self, Keypair},
@@ -519,9 +519,9 @@ impl DkgCommand {
                     recipients.clone(),
                     recipients.len(),
                     message,
-                    DestInfo {
-                        dest: XorName::random(),
-                        dest_section_pk: key,
+                    DstInfo {
+                        dst: XorName::random(),
+                        dst_section_pk: key,
                     },
                 ))
             }
@@ -553,9 +553,9 @@ impl DkgCommand {
                     recipients.clone(),
                     recipients.len(),
                     message,
-                    DestInfo {
-                        dest: XorName::random(),
-                        dest_section_pk: key,
+                    DstInfo {
+                        dst: XorName::random(),
+                        dst_section_pk: key,
                     },
                 ))
             }

--- a/src/routing/dkg/commands.rs
+++ b/src/routing/dkg/commands.rs
@@ -8,7 +8,7 @@
 
 use crate::messaging::{
     node::{DkgFailureSigned, DkgFailureSignedSet, DkgKey, RoutingMsg, Variant},
-    DestInfo, DstLocation, SectionAuthorityProvider,
+    DstInfo, DstLocation, SectionAuthorityProvider,
 };
 use crate::routing::{
     error::Result, messages::RoutingMsgUtils, node::Node, routing::command::Command,
@@ -57,9 +57,9 @@ impl DkgCommand {
                     recipients.clone(),
                     recipients.len(),
                     message,
-                    DestInfo {
-                        dest: XorName::random(),
-                        dest_section_pk: key,
+                    DstInfo {
+                        dst: XorName::random(),
+                        dst_section_pk: key,
                     },
                 ))
             }
@@ -91,9 +91,9 @@ impl DkgCommand {
                     recipients.clone(),
                     recipients.len(),
                     message,
-                    DestInfo {
-                        dest: XorName::random(),
-                        dest_section_pk: key,
+                    DstInfo {
+                        dst: XorName::random(),
+                        dst_section_pk: key,
                     },
                 ))
             }

--- a/src/routing/routing/comm.rs
+++ b/src/routing/routing/comm.rs
@@ -120,7 +120,7 @@ impl Comm {
         recipient: (XorName, SocketAddr),
         mut msg: MessageType,
     ) -> Result<(), Error> {
-        msg.update_dest_info(None, Some(recipient.0));
+        msg.update_dst_info(None, Some(recipient.0));
 
         let bytes = msg.serialize()?;
         self.endpoint
@@ -198,7 +198,7 @@ impl Comm {
         }
         // Use the first Xor address recipient to represent the destination section.
         // So that only one copy of MessageType need to be constructed.
-        msg.update_dest_info(None, Some(recipients[0].0));
+        msg.update_dst_info(None, Some(recipients[0].0));
 
         let msg_bytes = msg.serialize().map_err(Error::Messaging)?;
 
@@ -347,7 +347,7 @@ pub enum SendStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::messaging::{section_info::SectionInfoMsg, DestInfo, WireMsg};
+    use crate::messaging::{section_info::SectionInfoMsg, DstInfo, WireMsg};
     use anyhow::Result;
     use assert_matches::assert_matches;
     use futures::future;
@@ -379,7 +379,7 @@ mod tests {
         assert_matches!(status, SendStatus::AllRecipients);
 
         if let Some(bytes) = peer0.rx.recv().await {
-            original_message.update_dest_info(None, Some(peer0._name));
+            original_message.update_dst_info(None, Some(peer0._name));
             assert_eq!(WireMsg::deserialize(bytes)?, original_message.clone());
         }
 
@@ -410,7 +410,7 @@ mod tests {
         assert_matches!(status, SendStatus::AllRecipients);
 
         if let Some(bytes) = peer0.rx.recv().await {
-            original_message.update_dest_info(None, Some(peer0._name));
+            original_message.update_dst_info(None, Some(peer0._name));
             assert_eq!(WireMsg::deserialize(bytes)?, original_message);
         }
 
@@ -478,7 +478,7 @@ mod tests {
 
         // Using first name of the recipients to represent section_name.
         if let Some(bytes) = peer.rx.recv().await {
-            message.update_dest_info(None, Some(name));
+            message.update_dst_info(None, Some(name));
             assert_eq!(WireMsg::deserialize(bytes)?, message);
         }
         Ok(())
@@ -515,7 +515,7 @@ mod tests {
 
         // Using first name of the recipients to represent section_name.
         if let Some(bytes) = peer.rx.recv().await {
-            message.update_dest_info(None, Some(name));
+            message.update_dst_info(None, Some(name));
             assert_eq!(WireMsg::deserialize(bytes)?, message);
         }
         Ok(())
@@ -535,9 +535,9 @@ mod tests {
         let key0 = bls::SecretKey::random().public_key();
         let msg0 = MessageType::SectionInfo {
             msg: SectionInfoMsg::GetSectionQuery(PublicKey::Bls(key0)),
-            dest_info: DestInfo {
-                dest: name,
-                dest_section_pk: key0,
+            dst_info: DstInfo {
+                dst: name,
+                dst_section_pk: key0,
             },
         };
         let _ = send_comm
@@ -560,9 +560,9 @@ mod tests {
         let key1 = bls::SecretKey::random().public_key();
         let msg1 = MessageType::SectionInfo {
             msg: SectionInfoMsg::GetSectionQuery(PublicKey::Bls(key1)),
-            dest_info: DestInfo {
-                dest: name,
-                dest_section_pk: key1,
+            dst_info: DstInfo {
+                dst: name,
+                dst_section_pk: key1,
             },
         };
         let _ = send_comm
@@ -623,9 +623,9 @@ mod tests {
         let random_bls_pk = bls::SecretKey::random().public_key();
         MessageType::SectionInfo {
             msg: SectionInfoMsg::GetSectionQuery(PublicKey::Bls(random_bls_pk)),
-            dest_info: DestInfo {
-                dest: XorName::random(),
-                dest_section_pk: bls::SecretKey::random().public_key(),
+            dst_info: DstInfo {
+                dst: XorName::random(),
+                dst_section_pk: bls::SecretKey::random().public_key(),
             },
         }
     }

--- a/src/routing/routing/command.rs
+++ b/src/routing/routing/command.rs
@@ -9,7 +9,7 @@
 use crate::messaging::{
     node::{DkgFailureSignedSet, Proposal, RoutingMsg, Section, Signed},
     section_info::SectionInfoMsg,
-    DestInfo, Itinerary, MessageType, SectionAuthorityProvider,
+    DstInfo, Itinerary, MessageType, SectionAuthorityProvider,
 };
 use crate::routing::{node::Node, routing::Peer, section::SectionKeyShare, XorName};
 use bytes::Bytes;
@@ -30,13 +30,13 @@ pub(crate) enum Command {
     HandleMessage {
         sender: Option<SocketAddr>,
         message: RoutingMsg,
-        dest_info: DestInfo,
+        dst_info: DstInfo,
     },
     /// Handle network info message.
     HandleSectionInfoMsg {
         sender: SocketAddr,
         message: SectionInfoMsg,
-        dest_info: DestInfo,
+        dst_info: DstInfo,
     },
     /// Handle a timeout previously scheduled with `ScheduleTimeout`.
     HandleTimeout(u64),
@@ -84,7 +84,7 @@ pub(crate) enum Command {
         // Previous name if relocated.
         previous_name: Option<XorName>,
         // The key of the destination section that the joining node knows, if any.
-        destination_key: Option<bls::PublicKey>,
+        dst_key: Option<bls::PublicKey>,
     },
     /// Proposes a peer as offline
     ProposeOffline(XorName),
@@ -100,9 +100,9 @@ impl Command {
     pub fn send_message_to_node(
         recipient: (XorName, SocketAddr),
         routing_msg: RoutingMsg,
-        dest_info: DestInfo,
+        dst_info: DstInfo,
     ) -> Self {
-        Self::send_message_to_nodes(vec![recipient], 1, routing_msg, dest_info)
+        Self::send_message_to_nodes(vec![recipient], 1, routing_msg, dst_info)
     }
 
     /// Convenience method to create `Command::SendMessage` with multiple recipients.
@@ -110,12 +110,12 @@ impl Command {
         recipients: Vec<(XorName, SocketAddr)>,
         delivery_group_size: usize,
         msg: RoutingMsg,
-        dest_info: DestInfo,
+        dst_info: DstInfo,
     ) -> Self {
         Self::SendMessage {
             recipients,
             delivery_group_size,
-            message: MessageType::Routing { dest_info, msg },
+            message: MessageType::Routing { dst_info, msg },
         }
     }
 }
@@ -126,22 +126,22 @@ impl Debug for Command {
             Self::HandleMessage {
                 sender,
                 message,
-                dest_info,
+                dst_info,
             } => f
                 .debug_struct("HandleMessage")
                 .field("sender", sender)
                 .field("message", message)
-                .field("dest_info", dest_info)
+                .field("dst_info", dst_info)
                 .finish(),
             Self::HandleSectionInfoMsg {
                 sender,
                 message,
-                dest_info,
+                dst_info,
             } => f
                 .debug_struct("HandleSectionInfoMsg")
                 .field("sender", sender)
                 .field("message", message)
-                .field("dest_info", dest_info)
+                .field("dst_info", dst_info)
                 .finish(),
             Self::HandleTimeout(token) => f.debug_tuple("HandleTimeout").field(token).finish(),
             Self::HandleConnectionLost(addr) => {

--- a/src/routing/routing/core/anti_entropy.rs
+++ b/src/routing/routing/core/anti_entropy.rs
@@ -8,7 +8,7 @@
 
 use crate::messaging::{
     node::{RoutingMsg, Section, Variant},
-    DestInfo,
+    DstInfo,
 };
 use crate::routing::{
     error::Result,
@@ -26,7 +26,7 @@ pub(crate) fn process(
     node: &Node,
     section: &Section,
     msg: &RoutingMsg,
-    dest_info: DestInfo,
+    dst_info: DstInfo,
 ) -> Result<(Actions, bool)> {
     let mut actions = Actions::default();
 
@@ -41,12 +41,12 @@ pub(crate) fn process(
 
     if let Ordering::Less = section
         .chain()
-        .cmp_by_position(&dest_info.dest_section_pk, section.chain().last_key())
+        .cmp_by_position(&dst_info.dst_section_pk, section.chain().last_key())
     {
         info!("Anti-Entropy: Source's knowledge of our key is outdated, send them an update.");
         let chain = section
             .chain()
-            .get_proof_chain_to_current(&dest_info.dest_section_pk)?;
+            .get_proof_chain_to_current(&dst_info.dst_section_pk)?;
         let section_auth = section.section_signed_authority_provider();
         let variant = Variant::SectionKnowledge {
             src_info: (section_auth.clone(), chain),
@@ -94,12 +94,12 @@ mod tests {
             &env.their_prefix,
             env.section.authority_provider().section_key(),
         )?;
-        let dest_info = DestInfo {
-            dest: XorName::random(),
-            dest_section_pk: *env.section.chain().last_key(),
+        let dst_info = DstInfo {
+            dst: XorName::random(),
+            dst_section_pk: *env.section.chain().last_key(),
         };
 
-        let (actions, _) = process(&env.node, &env.section, &msg, dest_info)?;
+        let (actions, _) = process(&env.node, &env.section, &msg, dst_info)?;
         assert_eq!(actions.send, vec![]);
 
         Ok(())
@@ -116,12 +116,12 @@ mod tests {
             env.section.prefix(),
             env.section.authority_provider().section_key(),
         )?;
-        let dest_info = DestInfo {
-            dest: env.node.name(),
-            dest_section_pk: our_new_pk,
+        let dst_info = DstInfo {
+            dst: env.node.name(),
+            dst_section_pk: our_new_pk,
         };
 
-        let (actions, _) = process(&env.node, &env.section, &msg, dest_info)?;
+        let (actions, _) = process(&env.node, &env.section, &msg, dst_info)?;
 
         assert_eq!(actions.send, vec![]);
 
@@ -136,12 +136,12 @@ mod tests {
             &env.their_prefix,
             env.section.authority_provider().section_key(),
         )?;
-        let dest_info = DestInfo {
-            dest: XorName::random(),
-            dest_section_pk: *env.section.chain().root_key(),
+        let dst_info = DstInfo {
+            dst: XorName::random(),
+            dst_section_pk: *env.section.chain().root_key(),
         };
 
-        let (mut actions, _) = process(&env.node, &env.section, &msg, dest_info)?;
+        let (mut actions, _) = process(&env.node, &env.section, &msg, dst_info)?;
 
         assert_matches!(&actions.send.pop(), Some(message) => {
             assert_matches!(message.variant, Variant::SectionKnowledge { ref src_info, .. } => {
@@ -161,12 +161,12 @@ mod tests {
             env.section.prefix(),
             env.section.authority_provider().section_key(),
         )?;
-        let dest_info = DestInfo {
-            dest: XorName::random(),
-            dest_section_pk: *env.section.chain().root_key(),
+        let dst_info = DstInfo {
+            dst: XorName::random(),
+            dst_section_pk: *env.section.chain().root_key(),
         };
 
-        let (actions, _) = process(&env.node, &env.section, &msg, dest_info)?;
+        let (actions, _) = process(&env.node, &env.section, &msg, dst_info)?;
 
         assert_eq!(actions.send, vec![]);
 

--- a/src/routing/routing/core/api.rs
+++ b/src/routing/routing/core/api.rs
@@ -10,7 +10,7 @@ use super::{delivery_group, Core};
 use crate::messaging::{
     node::{Network, NodeState, Peer, Proposal, RoutingMsg, Section, Variant},
     section_info::Error as TargetSectionError,
-    DestInfo, EndUser, Itinerary, SectionAuthorityProvider, SrcLocation,
+    DstInfo, EndUser, Itinerary, SectionAuthorityProvider, SrcLocation,
 };
 use crate::routing::{
     error::Result,
@@ -141,7 +141,7 @@ impl Core {
         )?;
 
         let target_name = msg.dst.name().ok_or(Error::CannotRoute)?;
-        let dest_pk = self.section_key_by_name(&target_name);
+        let dst_pk = self.section_key_by_name(&target_name);
 
         let mut targets = vec![];
 
@@ -172,9 +172,9 @@ impl Core {
             targets,
             dg_size,
             msg.clone(),
-            DestInfo {
-                dest: XorName::random(),
-                dest_section_pk: dest_pk,
+            DstInfo {
+                dst: XorName::random(),
+                dst_section_pk: dst_pk,
             },
         );
 
@@ -243,7 +243,7 @@ impl Core {
             );
             return Err(Error::InvalidDstLocation);
         };
-        let dest_section_pk = self.section_key_by_name(&dst_name);
+        let dst_section_pk = self.section_key_by_name(&dst_name);
 
         let variant = Variant::UserMessage(content.to_vec());
 
@@ -278,9 +278,9 @@ impl Core {
             commands.push(Command::HandleMessage {
                 sender: Some(self.node.addr),
                 message: msg.clone(),
-                dest_info: DestInfo {
-                    dest: dst_name,
-                    dest_section_pk,
+                dst_info: DstInfo {
+                    dst: dst_name,
+                    dst_section_pk,
                 },
             });
         }
@@ -303,12 +303,12 @@ impl Core {
         &self,
         peer: Peer,
         previous_name: Option<XorName>,
-        destination_key: Option<bls::PublicKey>,
+        dst_key: Option<bls::PublicKey>,
     ) -> Result<Vec<Command>> {
         self.propose(Proposal::Online {
             node_state: NodeState::joined(peer),
             previous_name,
-            destination_key,
+            dst_key,
         })
     }
 }

--- a/src/routing/routing/core/delivery_group.rs
+++ b/src/routing/routing/core/delivery_group.rs
@@ -30,11 +30,11 @@ use xor_name::XorName;
 ///
 /// * If the destination is a `DstLocation::Section` OR `DstLocation::EndUser`:
 ///     - if our section is the closest on the network (i.e. our section's prefix is a prefix of
-///       the destination), returns all other members of our section; otherwise
+///       the dst), returns all other members of our section; otherwise
 ///     - returns the `N/3` closest members to the target
 ///
 /// * If the destination is an individual node:
-///     - if our name *is* the destination, returns an empty set; otherwise
+///     - if our name *is* the dst, returns an empty set; otherwise
 ///     - if the destination name is an entry in the routing table, returns it; otherwise
 ///     - returns the `N/3` closest members of the RT to the target
 pub(crate) fn delivery_targets(

--- a/src/routing/routing/core/messaging/handling/agreement.rs
+++ b/src/routing/routing/core/messaging/handling/agreement.rs
@@ -13,7 +13,7 @@ use crate::messaging::{
         MembershipState, NodeState, PlainMessage, Proposal, RoutingMsg, SectionSigned, Signed,
         Variant,
     },
-    DestInfo, DstLocation, SectionAuthorityProvider,
+    DstInfo, DstLocation, SectionAuthorityProvider,
 };
 use crate::routing::{
     dkg::SectionSignedUtils,
@@ -60,7 +60,7 @@ impl Core {
                 self.handle_our_elders_agreement(section_auth, signed).await
             }
             Proposal::AccumulateAtSrc { message, .. } => {
-                let dest_name = if let Some(name) = message.dst.name() {
+                let dst_name = if let Some(name) = message.dst.name() {
                     name
                 } else {
                     error!(
@@ -69,14 +69,14 @@ impl Core {
                     );
                     return Err(Error::InvalidDstLocation);
                 };
-                let dest_section_pk = message.dst_key;
+                let dst_section_pk = message.dst_key;
                 Ok(vec![self.handle_accumulate_at_src_agreement(
                     *message,
                     self.section.chain().clone(),
                     signed,
-                    DestInfo {
-                        dest: dest_name,
-                        dest_section_pk,
+                    DstInfo {
+                        dst: dst_name,
+                        dst_section_pk,
                     },
                 )?])
             }
@@ -241,9 +241,9 @@ impl Core {
                     sync_recipients,
                     len,
                     sync_message,
-                    DestInfo {
-                        dest: XorName::random(),
-                        dest_section_pk: signed.public_key,
+                    DstInfo {
+                        dst: XorName::random(),
+                        dst_section_pk: signed.public_key,
                     },
                 ));
             }
@@ -299,14 +299,14 @@ impl Core {
         message: PlainMessage,
         section_chain: SecuredLinkedList,
         signed: Signed,
-        dest_info: DestInfo,
+        dst_info: DstInfo,
     ) -> Result<Command> {
         let message = RoutingMsg::section_src(message, signed, section_chain)?;
 
         Ok(Command::HandleMessage {
             message,
             sender: None,
-            dest_info,
+            dst_info,
         })
     }
 }

--- a/src/routing/routing/core/messaging/handling/bad_msgs.rs
+++ b/src/routing/routing/core/messaging/handling/bad_msgs.rs
@@ -9,7 +9,7 @@
 use super::Core;
 use crate::messaging::{
     node::{Peer, RoutingMsg, Variant},
-    DestInfo, DstLocation,
+    DstInfo, DstLocation,
 };
 use crate::routing::{
     messages::{RoutingMsgUtils, SrcAuthorityUtils},
@@ -28,26 +28,26 @@ impl Core {
         &self,
         sender: Option<SocketAddr>,
         msg: RoutingMsg,
-        received_dest_info: DestInfo,
+        received_dst_info: DstInfo,
     ) -> Result<Command> {
         let src_name = msg.src.name();
         let bounce_dst_key = self.section_key_by_name(&src_name);
-        let dest_info = DestInfo {
-            dest: src_name,
-            dest_section_pk: bounce_dst_key,
+        let dst_info = DstInfo {
+            dst: src_name,
+            dst_section_pk: bounce_dst_key,
         };
         let bounce_msg = RoutingMsg::single_src(
             &self.node,
             DstLocation::DirectAndUnrouted,
             Variant::BouncedUntrustedMessage {
                 msg: Box::new(msg),
-                dest_info: received_dest_info,
+                dst_info: received_dst_info,
             },
             self.section.authority_provider().section_key(),
         )?;
 
         let cmd = if let Some(sender) = sender {
-            Command::send_message_to_node((src_name, sender), bounce_msg, dest_info)
+            Command::send_message_to_node((src_name, sender), bounce_msg, dst_info)
         } else {
             self.send_message_to_our_elders(bounce_msg)
         };
@@ -91,15 +91,15 @@ impl Core {
             }
         };
 
-        let dest_info = DestInfo {
-            dest: *sender.name(),
-            dest_section_pk: dst_key,
+        let dst_info = DstInfo {
+            dst: *sender.name(),
+            dst_section_pk: dst_key,
         };
         trace!("resending with extended signed");
         Ok(Command::send_message_to_node(
             (*sender.name(), *sender.addr()),
             resend_msg,
-            dest_info,
+            dst_info,
         ))
     }
 }

--- a/src/routing/routing/core/messaging/handling/relocation.rs
+++ b/src/routing/routing/core/messaging/handling/relocation.rs
@@ -56,11 +56,11 @@ impl Core {
             debug!(
                 "Relocating {:?} to {} (on churn of {})",
                 peer,
-                action.destination(),
+                action.dst(),
                 churn_name
             );
 
-            commands.extend(self.propose(Proposal::Offline(info.relocate(*action.destination())))?);
+            commands.extend(self.propose(Proposal::Offline(info.relocate(*action.dst())))?);
 
             match action {
                 RelocateAction::Instant(details) => {
@@ -82,7 +82,7 @@ impl Core {
         trace!(
             "Relocating {:?} to {} with age {} due to rejoin",
             peer,
-            details.destination,
+            details.dst,
             details.age
         );
 
@@ -101,7 +101,7 @@ impl Core {
 
         debug!(
             "Received Relocate message to join the section at {}",
-            details.relocate_details()?.destination
+            details.relocate_details()?.dst
         );
 
         match self.relocate_state {
@@ -144,10 +144,7 @@ impl Core {
             // Keep it around even if we are not elder anymore, in case we need to resend it.
             match self.relocate_state {
                 None => {
-                    trace!(
-                        "Received RelocatePromise to section at {}",
-                        promise.destination
-                    );
+                    trace!("Received RelocatePromise to section at {}", promise.dst);
                     self.relocate_state = Some(RelocateState::Delayed(msg.clone()));
                     self.send_event(Event::RelocationStarted {
                         previous_name: self.node.name(),
@@ -179,12 +176,8 @@ impl Core {
         }
 
         if let Some(info) = self.section.members().get(&promise.name) {
-            let details = RelocateDetails::new(
-                &self.section,
-                &self.network,
-                &info.peer,
-                promise.destination,
-            );
+            let details =
+                RelocateDetails::new(&self.section, &self.network, &info.peer, promise.dst);
             commands.extend(self.send_relocate(&info.peer, details)?);
         } else {
             error!(

--- a/src/routing/routing/core/messaging/sending.rs
+++ b/src/routing/routing/core/messaging/sending.rs
@@ -12,7 +12,7 @@ use crate::messaging::{
         DkgKey, ElderCandidates, JoinResponse, Network, NodeState, Peer, PlainMessage, Proposal,
         RelocateDetails, RelocatePromise, RoutingMsg, Section, SectionSigned, Variant,
     },
-    DestInfo, DstLocation,
+    DstInfo, DstLocation,
 };
 use crate::routing::{
     dkg::DkgKeyUtils,
@@ -61,9 +61,9 @@ impl Core {
         Ok(Command::send_message_to_node(
             (name, addr),
             message,
-            DestInfo {
-                dest: name,
-                dest_section_pk: *self.section.chain().last_key(),
+            DstInfo {
+                dst: name,
+                dst_section_pk: *self.section.chain().last_key(),
             },
         ))
     }
@@ -78,15 +78,15 @@ impl Core {
                 variant,
                 self.section.authority_provider().section_key(),
             )?;
-            let dest_info = DestInfo {
-                dest: XorName::random(),
-                dest_section_pk: *self.section.chain().last_key(),
+            let dst_info = DstInfo {
+                dst: XorName::random(),
+                dst_section_pk: *self.section.chain().last_key(),
             };
             Ok(Command::send_message_to_nodes(
                 recipients.clone(),
                 recipients.len(),
                 message,
-                dest_info,
+                dst_info,
             ))
         };
 
@@ -129,9 +129,9 @@ impl Core {
                 recipients.clone(),
                 recipients.len(),
                 message,
-                DestInfo {
-                    dest: XorName::random(),
-                    dest_section_pk: *self.section_chain().last_key(),
+                DstInfo {
+                    dst: XorName::random(),
+                    dst_section_pk: *self.section_chain().last_key(),
                 },
             ))
         };
@@ -308,14 +308,14 @@ impl Core {
 
         if !others.is_empty() {
             let count = others.len();
-            let dest_section_pk = self.section_key_by_name(&others[0].0);
+            let dst_section_pk = self.section_key_by_name(&others[0].0);
             commands.push(Command::send_message_to_nodes(
                 others,
                 count,
                 message.clone(),
-                DestInfo {
-                    dest: XorName::random(), // will be updated when sending
-                    dest_section_pk,
+                DstInfo {
+                    dst: XorName::random(), // will be updated when sending
+                    dst_section_pk,
                 },
             ));
         }
@@ -324,9 +324,9 @@ impl Core {
             commands.push(Command::HandleMessage {
                 sender: Some(self.node.addr),
                 message,
-                dest_info: DestInfo {
-                    dest: self.node.name(),
-                    dest_section_pk: *self.section_chain().last_key(),
+                dst_info: DstInfo {
+                    dst: self.node.name(),
+                    dst_section_pk: *self.section_chain().last_key(),
                 },
             });
         }
@@ -374,9 +374,9 @@ impl Core {
         Ok(Command::send_message_to_node(
             recipient,
             message,
-            DestInfo {
-                dest: recipient.0,
-                dest_section_pk: dst_pk,
+            DstInfo {
+                dst: recipient.0,
+                dst_section_pk: dst_pk,
             },
         ))
     }
@@ -392,13 +392,13 @@ impl Core {
             .map(|(name, address)| (*name, *address))
             .collect();
 
-        let dest_section_pk = *self.section_chain().last_key();
+        let dst_section_pk = *self.section_chain().last_key();
 
-        let dest_info = DestInfo {
-            dest: self.section.prefix().name(),
-            dest_section_pk,
+        let dst_info = DstInfo {
+            dst: self.section.prefix().name(),
+            dst_section_pk,
         };
 
-        Command::send_message_to_nodes(targets.clone(), targets.len(), msg, dest_info)
+        Command::send_message_to_nodes(targets.clone(), targets.len(), msg, dst_info)
     }
 }

--- a/src/routing/routing/core/mod.rs
+++ b/src/routing/routing/core/mod.rs
@@ -16,7 +16,7 @@ use super::{command::Command, enduser_registry::EndUserRegistry, split_barrier::
 use crate::messaging::node::SignatureAggregator;
 use crate::messaging::{
     node::{Network, Proposal, RoutingMsg, Section, SectionSigned, Variant},
-    DestInfo, DstLocation, MessageId, SectionAuthorityProvider,
+    DstInfo, DstLocation, MessageId, SectionAuthorityProvider,
 };
 use crate::routing::{
     dkg::{DkgVoter, ProposalAggregator},
@@ -98,7 +98,7 @@ impl Core {
     async fn check_for_entropy(
         &self,
         msg: &RoutingMsg,
-        dest_info: DestInfo,
+        dst_info: DstInfo,
     ) -> Result<(Vec<Command>, bool)> {
         if !self.is_elder() {
             // Adult nodes do need to carry out entropy checking, however the message shall always
@@ -107,7 +107,7 @@ impl Core {
         }
 
         let (actions, can_be_executed) =
-            anti_entropy::process(&self.node, &self.section, msg, dest_info)?;
+            anti_entropy::process(&self.node, &self.section, msg, dst_info)?;
         let mut commands = vec![];
 
         for msg in actions.send {
@@ -192,12 +192,12 @@ impl Core {
                         .map(|(name, addr)| (*name, *addr))
                         .collect();
                     let len = targets.len();
-                    let dest_info = DestInfo {
-                        dest: XorName::random(),
-                        dest_section_pk: sap.section_key(),
+                    let dst_info = DstInfo {
+                        dst: XorName::random(),
+                        dst_section_pk: sap.section_key(),
                     };
                     trace!("Sending updated SectionInfo to all known sections");
-                    commands.push(Command::send_message_to_nodes(targets, len, msg, dest_info));
+                    commands.push(Command::send_message_to_nodes(targets, len, msg, dst_info));
                 }
             }
 

--- a/src/routing/routing/dispatcher.rs
+++ b/src/routing/routing/dispatcher.rs
@@ -103,7 +103,7 @@ impl Dispatcher {
             Command::HandleMessage {
                 sender,
                 message,
-                dest_info,
+                dst_info,
             } => {
                 if let Some(sender) = &sender {
                     // let's then see if we need to do a reachability test
@@ -151,18 +151,18 @@ impl Dispatcher {
                 self.core
                     .write()
                     .await
-                    .handle_message(sender, message, dest_info)
+                    .handle_message(sender, message, dst_info)
                     .await
             }
             Command::HandleSectionInfoMsg {
                 sender,
                 message,
-                dest_info,
+                dst_info,
             } => Ok(self
                 .core
                 .write()
                 .await
-                .handle_section_info_msg(sender, message, dest_info)
+                .handle_section_info_msg(sender, message, dst_info)
                 .await),
             Command::HandleTimeout(token) => self.core.write().await.handle_timeout(token),
             Command::HandleAgreement { proposal, signed } => {
@@ -223,14 +223,14 @@ impl Dispatcher {
             Command::ProposeOnline {
                 mut peer,
                 previous_name,
-                destination_key,
+                dst_key,
             } => {
                 // The reachability check was completed during the initial bootstrap phase
                 peer.set_reachable(true);
                 self.core
                     .read()
                     .await
-                    .make_online_proposal(peer, previous_name, destination_key)
+                    .make_online_proposal(peer, previous_name, dst_key)
                     .await
             }
             Command::ProposeOffline(name) => self.core.read().await.propose_offline(name),

--- a/src/routing/section/member_info.rs
+++ b/src/routing/section/member_info.rs
@@ -35,7 +35,7 @@ pub trait MemberInfoUtils {
     fn leave(self) -> Result<MemberInfo, Error>;
 
     // Convert this info into one with the state changed to `Relocated`.
-    fn relocate(self, destination: XorName) -> MemberInfo;
+    fn relocate(self, dst: XorName) -> MemberInfo;
 }
 
 impl MemberInfoUtils for MemberInfo {
@@ -65,9 +65,9 @@ impl MemberInfoUtils for MemberInfo {
     }
 
     // Convert this info into one with the state changed to `Relocated`.
-    fn relocate(self, destination: XorName) -> MemberInfo {
+    fn relocate(self, dst: XorName) -> MemberInfo {
         MemberInfo {
-            state: PeerState::Relocated(destination),
+            state: PeerState::Relocated(dst),
             ..self
         }
     }

--- a/src/routing/section/node_state.rs
+++ b/src/routing/section/node_state.rs
@@ -35,7 +35,7 @@ pub trait NodeStateUtils {
     fn leave(self) -> Result<NodeState, Error>;
 
     // Convert this info into one with the state changed to `Relocated`.
-    fn relocate(self, destination: XorName) -> NodeState;
+    fn relocate(self, dst: XorName) -> NodeState;
 }
 
 impl NodeStateUtils for NodeState {
@@ -65,9 +65,9 @@ impl NodeStateUtils for NodeState {
     }
 
     // Convert this info into one with the state changed to `Relocated`.
-    fn relocate(self, destination: XorName) -> NodeState {
+    fn relocate(self, dst: XorName) -> NodeState {
         NodeState {
-            state: MembershipState::Relocated(destination),
+            state: MembershipState::Relocated(dst),
             ..self
         }
     }


### PR DESCRIPTION
- The common used shorts for `source` and `destination` are `src` and `dst`.
